### PR TITLE
Fix several deprecations

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,10 +43,10 @@ dependencies {
 // AndroidX
     implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+    implementation 'androidx.fragment:fragment:1.3.4'
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
     implementation 'androidx.preference:preference:1.1.1'
-    implementation 'androidx.recyclerview:recyclerview:1.2.0'
-    implementation 'androidx.fragment:fragment:1.3.4'
+    implementation 'androidx.recyclerview:recyclerview:1.2.1'
     implementation 'com.google.android.material:material:1.3.0'
 
 // Third-party

--- a/app/src/main/java/com/emanuelef/remote_capture/activities/AppsActivity.java
+++ b/app/src/main/java/com/emanuelef/remote_capture/activities/AppsActivity.java
@@ -22,6 +22,7 @@ package com.emanuelef.remote_capture.activities;
 import android.os.Bundle;
 
 import com.emanuelef.remote_capture.R;
+import com.emanuelef.remote_capture.fragments.AppsFragment;
 
 public class AppsActivity extends BaseActivity {
     private static final String TAG = "AppsActivity";
@@ -32,5 +33,9 @@ public class AppsActivity extends BaseActivity {
 
         setTitle(R.string.apps);
         setContentView(R.layout.apps_activity);
+
+        getSupportFragmentManager().beginTransaction()
+                .replace(R.id.apps_fragment, new AppsFragment())
+                .commit();
     }
 }

--- a/app/src/main/java/com/emanuelef/remote_capture/activities/MainActivity.java
+++ b/app/src/main/java/com/emanuelef/remote_capture/activities/MainActivity.java
@@ -106,6 +106,10 @@ public class MainActivity extends BaseActivity implements NavigationView.OnNavig
             registerForActivityResult(new StartActivityForResult(), this::captureServiceResult);
     private final ActivityResultLauncher<Intent> pcapFileLauncher =
             registerForActivityResult(new StartActivityForResult(), this::pcapFileResult);
+    private final ActivityResultLauncher<String> requestPermissionLauncher =
+            registerForActivityResult(new RequestPermission(), isGranted ->
+                Log.d(TAG, "Write permission " + (isGranted ? "granted" : "denied"))
+            );
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -226,15 +230,6 @@ public class MainActivity extends BaseActivity implements NavigationView.OnNavig
             }
         }
     }
-
-    private final ActivityResultLauncher<String> requestPermissionLauncher =
-            registerForActivityResult(new RequestPermission(), isGranted -> {
-                if (isGranted) {
-                    Log.d(TAG, "Write permission granted");
-                } else {
-                    Log.w(TAG, "Write permission denied");
-                }
-            });
 
     private static class MainStateAdapter extends FragmentStateAdapter {
         MainStateAdapter(final FragmentActivity fa) { super(fa); }

--- a/app/src/main/java/com/emanuelef/remote_capture/activities/MainActivity.java
+++ b/app/src/main/java/com/emanuelef/remote_capture/activities/MainActivity.java
@@ -33,6 +33,7 @@ import android.net.VpnService;
 
 import androidx.activity.result.ActivityResult;
 import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts.RequestPermission;
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBarDrawerToggle;
@@ -95,7 +96,6 @@ public class MainActivity extends BaseActivity implements NavigationView.OnNavig
     private static final int TOTAL_COUNT = 2;
 
     public static final String UID_FILTER_EXTRA = "uidFilter";
-    public static final int REQUEST_STORAGE_PERMISSIONS = 5;
 
     public static final String TELEGRAM_GROUP_NAME = "PCAPdroid";
     public static final String GITHUB_PROJECT_URL = "https://github.com/emanuele-f/PCAPdroid";
@@ -220,27 +220,21 @@ public class MainActivity extends BaseActivity implements NavigationView.OnNavig
                 if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                     // Needed to write file on devices which do not support ACTION_CREATE_DOCUMENT
                     if (checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
-                        requestPermissions(new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE}, REQUEST_STORAGE_PERMISSIONS);
+                        requestPermissionLauncher.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE);
                     }
                 }
             }
         }
     }
 
-    @Override
-    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-
-        switch(requestCode) {
-            case REQUEST_STORAGE_PERMISSIONS:
-                if(grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+    private final ActivityResultLauncher<String> requestPermissionLauncher =
+            registerForActivityResult(new RequestPermission(), isGranted -> {
+                if (isGranted) {
                     Log.d(TAG, "Write permission granted");
                 } else {
                     Log.w(TAG, "Write permission denied");
                 }
-                break;
-        }
-    }
+            });
 
     private static class MyStateAdapter extends FragmentStateAdapter {
         MyStateAdapter(final FragmentActivity fa) { super(fa); }

--- a/app/src/main/java/com/emanuelef/remote_capture/activities/MainActivity.java
+++ b/app/src/main/java/com/emanuelef/remote_capture/activities/MainActivity.java
@@ -236,8 +236,8 @@ public class MainActivity extends BaseActivity implements NavigationView.OnNavig
                 }
             });
 
-    private static class MyStateAdapter extends FragmentStateAdapter {
-        MyStateAdapter(final FragmentActivity fa) { super(fa); }
+    private static class MainStateAdapter extends FragmentStateAdapter {
+        MainStateAdapter(final FragmentActivity fa) { super(fa); }
 
         @NonNull
         @Override
@@ -255,23 +255,25 @@ public class MainActivity extends BaseActivity implements NavigationView.OnNavig
 
         @Override
         public int getItemCount() {  return TOTAL_COUNT;  }
-    }
 
-    private void setupTabs() {
-        final MyStateAdapter stateAdapter = new MyStateAdapter(this);
-        mPager.setAdapter(stateAdapter);
-
-        new TabLayoutMediator(mTabLayout, mPager, (tab, position) -> {
+        public int getPageTitle(final int position) {
             switch (position) {
                 default: // Deliberate fall-through to status tab
                 case POS_STATUS:
-                    tab.setText(R.string.status);
-                    break;
+                    return R.string.status;
                 case POS_CONNECTIONS:
-                    tab.setText(R.string.connections_view);
-                    break;
+                    return R.string.connections_view;
             }
-        }).attach();
+        }
+    }
+
+    private void setupTabs() {
+        final MainStateAdapter stateAdapter = new MainStateAdapter(this);
+        mPager.setAdapter(stateAdapter);
+
+        new TabLayoutMediator(mTabLayout, mPager, (tab, position) ->
+                tab.setText(getString(stateAdapter.getPageTitle(position)))
+        ).attach();
 
         checkUidFilterIntent(getIntent());
     }

--- a/app/src/main/java/com/emanuelef/remote_capture/activities/SettingsActivity.java
+++ b/app/src/main/java/com/emanuelef/remote_capture/activities/SettingsActivity.java
@@ -49,14 +49,15 @@ public class SettingsActivity extends BaseActivity {
         setTitle(R.string.title_activity_settings); // note: setting via manifest does not honor custom locale
         setContentView(R.layout.settings_activity);
 
-        getSupportFragmentManager()
-                .beginTransaction()
-                .replace(R.id.settings, new SettingsFragment())
-                .commit();
         ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {
             actionBar.setDisplayHomeAsUpEnabled(true);
         }
+
+        getSupportFragmentManager()
+                .beginTransaction()
+                .replace(R.id.settings_container, new SettingsFragment())
+                .commit();
     }
 
     @Override

--- a/app/src/main/java/com/emanuelef/remote_capture/fragments/ConnectionsFragment.java
+++ b/app/src/main/java/com/emanuelef/remote_capture/fragments/ConnectionsFragment.java
@@ -40,6 +40,9 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.activity.result.ActivityResult;
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
@@ -89,6 +92,9 @@ public class ConnectionsFragment extends Fragment implements ConnectionsListener
     private Uri mCsvFname;
     private boolean hasUntrackedConnections;
     private AppsResolver mApps;
+
+    private final ActivityResultLauncher<Intent> csvFileLauncher =
+            registerForActivityResult(new StartActivityForResult(), this::csvFileResult);
 
     @Override
     public void onResume() {
@@ -553,7 +559,7 @@ public class ConnectionsFragment extends Fragment implements ConnectionsListener
 
         if(Utils.supportsFileDialog(requireContext(), intent)) {
             try {
-                startActivityForResult(intent, MainActivity.REQUEST_CODE_CSV_FILE);
+                csvFileLauncher.launch(intent);
             } catch (ActivityNotFoundException e) {
                 noFileDialog = true;
             }
@@ -574,16 +580,12 @@ public class ConnectionsFragment extends Fragment implements ConnectionsListener
         }
     }
 
-    @Override
-    public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        super.onActivityResult(requestCode, resultCode, data);
-
-        if(requestCode == MainActivity.REQUEST_CODE_CSV_FILE) {
-            if(resultCode == Activity.RESULT_OK) {
-                mCsvFname = data.getData();
-                dumpCsv();
-            } else
-                mCsvFname = null;
+    private void csvFileResult(final ActivityResult result) {
+        if (result.getResultCode() == Activity.RESULT_OK && result.getData() != null) {
+            mCsvFname = result.getData().getData();
+            dumpCsv();
+        } else {
+            mCsvFname = null;
         }
     }
 }

--- a/app/src/main/res/layout/apps_activity.xml
+++ b/app/src/main/res/layout/apps_activity.xml
@@ -4,10 +4,9 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <fragment
+    <androidx.fragment.app.FragmentContainerView
         android:id="@+id/apps_fragment"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:name="com.emanuelef.remote_capture.fragments.AppsFragment" />
+        android:layout_height="wrap_content" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/settings_activity.xml
+++ b/app/src/main/res/layout/settings_activity.xml
@@ -3,8 +3,8 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <FrameLayout
-        android:id="@+id/settings"
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/settings_container"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1" />

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### 1st commit
- Update gradle to 7.0.2 using git bash
- Update RecyclerView 1.2.0 -> 1.2.1 ([changelog](https://developer.android.com/jetpack/androidx/releases/recyclerview#version_121_3))

### 2nd commit
- Utilize FragmentContainerView (see [here](https://developer.android.com/jetpack/androidx/releases/fragment#1.2.0))

### 3rd commit
- See [this](https://developer.android.com/jetpack/androidx/releases/fragment#1.3.0-alpha04) for this and the next commit...
- Fix onActivityResult deprecations
- Use ContextCompat.startForegroundService [here](https://github.com/emanuele-f/PCAPdroid/commit/56f366955d032d6106f08cbb6e732d4789a9cf21#diff-1d2191f73ed5aaefe7b1e0b8a74e87054c2ff86a10bbed571a2f40626922b551R487)

### 4th commit
- Fix onRequestPermissionsResult deprecation

### 5th commit
- Rename MyStateAdapter to something more relevant
- Clean up the state adapter a bit (keeps more of the state adapter stuff under the one inner class)


Again, I was unable to test these changes myself due to building errors (that I cannot resolve due to lack of hard drive space), but I'm rather confident that these changes work.