### PR TITLE
Renamed app filter to target app

### DIFF
--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -10,7 +10,7 @@
     <string name="host">Главная ЭВМ</string>
     <string name="capture_not_running">Захват не проводится!</string>
     <string name="capture_not_started">Захват не начат!</string>
-    <string name="app_filter">Фильтр приложений</string>
+    <string name="app_filter">Целевое приложение</string>
     <string name="ready">Готов</string>
     <string name="about">О</string>
     <string name="status">Состояние</string>
@@ -79,7 +79,7 @@
     <string name="delete_error">Невозможно удалить файл</string>
     <string name="capture_running">Захват проводится</string>
     <string name="notification_msg">%1$s захвачено, %2$s соединения</string>
-    <string name="no_app_filter">Фильтр приложений не установлен</string>
+    <string name="no_app_filter">Целевое приложение не выбрано</string>
     <string name="proto_and_port">%1$s, %2$d</string>
     <string name="conn_status_open">Открыто</string>
     <string name="first_seen">Впервые обнаружено</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,7 +19,7 @@
     <string name="host">Host</string>
     <string name="capture_not_running">Capture not running!</string>
     <string name="capture_not_started">Capture not started!</string>
-    <string name="app_filter">App Filter</string>
+    <string name="app_filter">Target app</string>
     <string name="ready">Ready</string>
     <string name="about">About</string>
     <string name="status">Status</string>
@@ -88,7 +88,7 @@
     <string name="delete_error">Could not delete file</string>
     <string name="capture_running">Capture running</string>
     <string name="notification_msg">%1$s captured, %2$s connections</string>
-    <string name="no_app_filter">No app filter set</string>
+    <string name="no_app_filter">Target app is not selected</string>
     <string name="proto_and_port">%1$s, %2$d</string>
     <string name="conn_status_open">Open</string>
     <string name="first_seen">First Seen</string>


### PR DESCRIPTION
I guess that "Target app" is a bit more relevant than "App filter", so strings which are visible in UI was renamed.
Id of strings are not changed, only values.