### PR TITLE
Added github action to build debug apk on each push and pull request

### DIFF
--- a/.github/workflows/debug-build.yml
+++ b/.github/workflows/debug-build.yml
@@ -1,0 +1,20 @@
+name: Debug build
+
+on: [push, pull_request]
+   
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: 'recursive'
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - run: ./gradlew assembleDebug
+    - uses: actions/upload-artifact@v2
+      with:
+        name: PCAPdroid build ${{github.sha}}
+        path: app/build/outputs/apk/debug/app-debug.apk
+        retention-days: 7


### PR DESCRIPTION
Average build time was about 3-4 minutes.

If I not mistaken, there's no way to upload built apk directly, it always will be zipped.
At least I tried to specify only path to file without artifact name property - file was uploaded into `artifact.zip` file.

At this moment I set artifact (zip) name as `PCAPdroid build ${{github.sha}}` where [`${{github.sha}}` provides a commit hash](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#github-context).

| `github.sha` | `string` | The commit SHA that triggered the workflow run. |
| ------------ | -------- | ----------------------------------------------- |

Artifact contains only `app-debug.apk` file.

Also I set [retention period](https://docs.github.com/en/actions/guides/storing-workflow-data-as-artifacts#configuring-a-custom-artifact-retention-period) inside config for 7 days (as you want)
