### PR TITLE
Spliting debug builds between pushes and pull requests

### DIFF
--- a/.github/workflows/pull-requests-debug-build.yml
+++ b/.github/workflows/pull-requests-debug-build.yml
@@ -1,6 +1,6 @@
-name: Debug build
+name: Pull Request builds
 
-on: [push, pull_request]
+on: pull_request
    
 jobs:
   build:

--- a/.github/workflows/pushes-debug-build.yml
+++ b/.github/workflows/pushes-debug-build.yml
@@ -1,0 +1,24 @@
+name: Latest debug build
+
+on: push
+   
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: 'recursive'
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - run: ./gradlew assembleDebug -PdoNotStrip
+    - uses: ncipollo/release-action@v1
+      with:
+        allowUpdates: true
+        prerelease: true
+        body: Debug build for commit ${{github.sha}}
+        replacesArtifacts: true
+        tag: "latest-debug"
+        artifacts: "app/build/outputs/apk/debug/app-debug.apk"
+        token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description

Old debug build config was saved, but renamed and limited to pull requests.
The new one triggered on pushes and publish debug builds as **_pre-release_**.

### Requirements

To be able to create (and update?) workflow permissions should be "read and write". Check it at repository settings > Actions > Workflow permissions (at the bottom of page)

### Details
 
- used action https://github.com/ncipollo/release-action
- used tag for releasing - `latest-debug`
- looks like by default action uses as body latest commit summary from master branch (didn't specified in readme), so release body now replaced with `Debug build for commit ${{github.sha}}`. In this case Github converts provided hash to link to related commit, also when hovering hash by mouse, Github provides popup with commit summary, author and time of commit
- as I understand published time didn't changed over updates, so only body with attachments is updated. That's why Github's popup with commit info is usefull to detect how fresh debug build is
- builds marked as **_pre-release_**, in this way they will not appear on main repo page and on the main repo-page will be last stable release
- apk name didn't changed, so it's `app-debug.apk`
- used option `replacesArtifacts: true` is required as soon as apk name is equal between builds. If you will change config to rename apk file, then you need to specify `removeArtifacts: true` instead. Otherwise new builds with different name will be just appended to release tag, and won't replace old builds

### Example of release in my fork

- Release tag - https://github.com/NEK-RA/PCAPdroid/releases/tag/latest-debug
- Workflow run - https://github.com/NEK-RA/PCAPdroid/runs/3612499795

Hope that I didn't forgot anything important