### PR TITLE
Use [address]:port notation for IPv6 address-port pair in connection details

### DIFF
--- a/app/src/main/java/com/emanuelef/remote_capture/fragments/ConnectionOverview.java
+++ b/app/src/main/java/com/emanuelef/remote_capture/fragments/ConnectionOverview.java
@@ -163,8 +163,13 @@ public class ConnectionOverview extends Fragment implements ConnectionDetailsAct
                 source.setText(mConn.src_ip);
                 destination.setText(mConn.dst_ip);
             } else {
-                source.setText(String.format(getResources().getString(R.string.ip_and_port), mConn.src_ip, mConn.src_port));
-                destination.setText(String.format(getResources().getString(R.string.ip_and_port), mConn.dst_ip, mConn.dst_port));
+                if (mConn.ipver == 6) {
+                    source.setText(String.format(getResources().getString(R.string.ipv6_and_port), mConn.src_ip, mConn.src_port));
+                    destination.setText(String.format(getResources().getString(R.string.ipv6_and_port), mConn.dst_ip, mConn.dst_port));
+                } else {
+                    source.setText(String.format(getResources().getString(R.string.ip_and_port), mConn.src_ip, mConn.src_port));
+                    destination.setText(String.format(getResources().getString(R.string.ip_and_port), mConn.dst_ip, mConn.dst_port));
+                }
             }
 
             if((mConn.info != null) && (!mConn.info.isEmpty())) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
     <string name="default_collector_ip" translatable="false">127.0.0.1</string>
     <string name="default_collector_port" translatable="false">1234</string>
     <string name="ip_and_port" translatable="false">%1$s:%2$d</string>
+    <string name="ipv6_and_port" translatable="false">[%1$s]:%2$d</string>
     <string name="app_and_proto" translatable="false">%1$s (%2$s)</string>
     <string name="sni" translatable="false">SNI</string>
     <string name="url" translatable="false">URL</string>


### PR DESCRIPTION
in Connection details, Source & Destination address-port pair currently uses address:port notation, which is fine for IPv4 but slightly ambiguous for IPv6.

in this PR I change the notation for IPv6 to [address]:port to make it less ambiguous.