### PR TITLE
For #314 , Change working directory before calling pcapd under su.

### DIFF
--- a/app/src/main/jni/common/utils.c
+++ b/app/src/main/jni/common/utils.c
@@ -240,6 +240,13 @@ int start_subprocess(const char *prog, const char *args, bool as_root, int* out_
         close(in_p[0]);
 
         // write "su" command input
+        if(as_root) {
+            char* cwd = getcwd(NULL, 0);
+            log_d("start_subprocess[%d]: cd %s", pid, cwd);
+            write(in_p[1], "cd ",3);
+            write(in_p[1], cwd, strlen(cwd));
+            write(in_p[1], "\n", 1);
+        }
         log_d("start_subprocess[%d]: %s %s", pid, prog, args);
         write(in_p[1], prog, strlen(prog));
         write(in_p[1], " ", 1);

--- a/app/src/main/jni/common/utils.c
+++ b/app/src/main/jni/common/utils.c
@@ -251,7 +251,7 @@ int start_subprocess(const char *prog, const char *args, bool as_root, int* out_
                 write(in_p[1], "\"\n", 2);
                 free(cwd);
             } else
-                log_w("start_subprocess[%d]: getcwd failed[%d], non-magisk su may fail",
+                log_w("start_subprocess[%d]: getcwd failed[%d]: %s - non-magisk 'su' may fail",
                       pid, errno, strerror(errno));
         }
 

--- a/app/src/main/jni/common/utils.c
+++ b/app/src/main/jni/common/utils.c
@@ -239,14 +239,22 @@ int start_subprocess(const char *prog, const char *args, bool as_root, int* out_
 
         close(in_p[0]);
 
-        // write "su" command input
+        // write "su"/"sh" command input
         if(as_root) {
+            // Some su implementations (e.g. Android-x86) change the PWD when activated,
+            // cd to the cache dir to ensure that the UNIX socket can be found by pcapd
             char* cwd = getcwd(NULL, 0);
-            log_d("start_subprocess[%d]: cd %s", pid, cwd);
-            write(in_p[1], "cd ",3);
-            write(in_p[1], cwd, strlen(cwd));
-            write(in_p[1], "\n", 1);
+            if (cwd) {
+                log_d("start_subprocess[%d]: cd %s", pid, cwd);
+                write(in_p[1], "cd \"",4);
+                write(in_p[1], cwd, strlen(cwd));
+                write(in_p[1], "\"\n", 2);
+                free(cwd);
+            } else
+                log_w("start_subprocess[%d]: getcwd failed[%d], non-magisk su may fail",
+                      pid, errno, strerror(errno));
         }
+
         log_d("start_subprocess[%d]: %s %s", pid, prog, args);
         write(in_p[1], prog, strlen(prog));
         write(in_p[1], " ", 1);


### PR DESCRIPTION
Some implementation of Android su will reset environment variables, so the current working directory will not be preserved.

To make sure the creation of pid file and log file, change working directory manually.



-------------

For #314 .

When running PCAPdroid under [Android x86 r9.0](https://www.android-x86.org/releases/releasenote-9-0-r2.html) with virt-manager. it failed to start when `capture as root`
The error message in the logcat 
```
pcapd could not open log file [30] : read only file system
pcapd pid file creation failed read only file system
```

I add log to pcapd's main function to print current working directory , like `log_d("%s", getcwd(NULL,0));`, and it output the current working dir is "/"

-------------

It looks like Magisk Su keep current working directory.
https://github.com/topjohnwu/Magisk/blob/master/native/src/core/su/su_daemon.cpp#L430-L434

But other su implementation don't do so. (it is easy to verify this. Open "Terminal Emulator" in Android x86 , cd to any directory other than "/" , then call `su` , the current working dir will change to "/" )
https://sourceforge.net/p/android-x86/external_koush_Superuser/ci/pie-x86/tree/Superuser/jni/su/

So we should change directory manually whatever su do it for us or not.

-----------

With this change, 

It works under Android x86 r9.0 with Superuser.
It also works with my Pixel 6 with Magisk Su.
