### PR TITLE
Include the package name in the CSV output

### DIFF
--- a/app/src/main/java/com/emanuelef/remote_capture/adapters/ConnectionsAdapter.java
+++ b/app/src/main/java/com/emanuelef/remote_capture/adapters/ConnectionsAdapter.java
@@ -470,6 +470,7 @@ public class ConnectionsAdapter extends RecyclerView.Adapter<ConnectionsAdapter.
                 builder.append(conn.dst_port);                              builder.append(",");
                 builder.append(conn.uid);                                   builder.append(",");
                 builder.append((app != null) ? app.getName() : "");         builder.append(",");
+                builder.append((app != null) ? app.getPackageName() : "");  builder.append(",");
                 builder.append(conn.l7proto);                               builder.append(",");
                 builder.append(conn.getStatusLabel(mContext));              builder.append(",");
                 builder.append((conn.info != null) ? conn.info : "");       builder.append(",");

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -32,7 +32,7 @@
         - App icon by <a href="https://www.freepik.com" title="Freepik">Freepik</a> from <a href="https://www.flaticon.com/" title="Flaticon">flaticon</a>\n\n
         - SourceCodePro font: <a href="https://github.com/adobe-fonts/source-code-pro/blob/release/LICENSE.md">OFL-1.1</a>\n\n
         </string>
-    <string name="connections_csv_fields" translatable="false">IPProto,SrcIP,SrcPort,DstIp,DstPort,UID,App,Proto,Status,Info,BytesSent,BytesRcvd,PktsSent,PktsRcvd,FirstSeen,LastSeen</string>
+    <string name="connections_csv_fields" translatable="false">IPProto,SrcIP,SrcPort,DstIp,DstPort,UID,App,PackageName,Proto,Status,Info,BytesSent,BytesRcvd,PktsSent,PktsRcvd,FirstSeen,LastSeen</string>
     <string name="unlock_token" translatable="false">Unlock token</string>
     <!-- Localized -->
     <string name="start_button">Start</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,7 +32,7 @@
         - App icon by <a href="https://www.freepik.com" title="Freepik">Freepik</a> from <a href="https://www.flaticon.com/" title="Flaticon">flaticon</a>\n\n
         - SourceCodePro font: <a href='https://github.com/adobe-fonts/source-code-pro/blob/release/LICENSE.md'>OFL-1.1</a>\n\n
         </string>
-    <string name="connections_csv_fields" translatable="false">IPProto,SrcIP,SrcPort,DstIp,DstPort,UID,App,Proto,Status,Info,BytesSent,BytesRcvd,PktsSent,PktsRcvd,FirstSeen,LastSeen</string>
+    <string name="connections_csv_fields" translatable="false">IPProto,SrcIP,SrcPort,DstIp,DstPort,UID,App,PackageName,Proto,Status,Info,BytesSent,BytesRcvd,PktsSent,PktsRcvd,FirstSeen,LastSeen</string>
     <string name="unlock_token" translatable="false">Unlock token</string>
 
     <!-- Localized -->


### PR DESCRIPTION
I've modified `dumpConnectionsCsv` and `connections_csv_fields` to include the package name as well as it's UID and display name.  This would be a very helpful addition for our use case.