### PR TITLE
Fixed the bug that the -q parameter cannot take effect

### DIFF
--- a/app/src/main/jni/pcapd/pcapd.c
+++ b/app/src/main/jni/pcapd/pcapd.c
@@ -1033,7 +1033,7 @@ static void parse_args(pcapd_conf_t *conf, int argc, char **argv) {
   init_conf(conf);
   opterr = 0;
 
-  while ((c = getopt (argc, argv, "hdtni:u:b:l:L:")) != -1) {
+  while ((c = getopt (argc, argv, "hdtnqi:u:b:l:L:")) != -1) {
     switch(c) {
       case 'i':
         if(conf->num_interfaces >= PCAPD_MAX_INTERFACES) {


### PR DESCRIPTION
Supplement the `q` parameter required in the `parse_args` function