### PR TITLE
Allow PCAPdroid capture control without prompt via API key

### DIFF
--- a/app/src/main/java/com/emanuelef/remote_capture/activities/CaptureCtrl.java
+++ b/app/src/main/java/com/emanuelef/remote_capture/activities/CaptureCtrl.java
@@ -106,6 +106,7 @@ public class CaptureCtrl extends AppCompatActivity {
 
         Intent intent = getIntent();
         String action = intent.getStringExtra("action");
+        String api_key = intent.getStringExtra("api_key");
 
         if(action == null) {
             Log.e(TAG, "no action provided");
@@ -116,6 +117,17 @@ public class CaptureCtrl extends AppCompatActivity {
         if(action.equals(ACTION_PEER_INFO)) {
             getPeerInfo();
             return;
+        }
+
+        if(api_key != null) {
+            // authenticate via API key
+            SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
+            String my_key = Prefs.getApiKey(prefs);
+
+            if (!my_key.isEmpty() && my_key.equals(api_key)) {
+                processRequest(intent, action);
+                return;
+            }
         }
 
         // Check if a control permission rule was set

--- a/app/src/main/java/com/emanuelef/remote_capture/activities/MainActivity.java
+++ b/app/src/main/java/com/emanuelef/remote_capture/activities/MainActivity.java
@@ -132,6 +132,7 @@ public class MainActivity extends BaseActivity implements NavigationView.OnNavig
     public static final String PAID_FEATURES_URL = DOCS_URL + "/paid_features";
     public static final String FIREWALL_DOCS_URL = PAID_FEATURES_URL + "#51-firewall";
     public static final String MALWARE_DETECTION_DOCS_URL = PAID_FEATURES_URL + "#52-malware-detection";
+    public static final String API_DOCS_URL = GITHUB_PROJECT_URL + "/blob/master/docs/app_api.md";
     public static final String PCAPNG_DOCS_URL = PAID_FEATURES_URL + "#53-pcapng-format";
 
     private final ActivityResultLauncher<Intent> sslkeyfileExportLauncher =

--- a/app/src/main/java/com/emanuelef/remote_capture/activities/prefs/SettingsActivity.java
+++ b/app/src/main/java/com/emanuelef/remote_capture/activities/prefs/SettingsActivity.java
@@ -461,14 +461,11 @@ public class SettingsActivity extends BaseActivity implements PreferenceFragment
             mIpMode = requirePreference(Prefs.PREF_IP_MODE);
 
             Preference ctrlPerm = requirePreference("control_permissions");
-            if(!PCAPdroid.getInstance().getCtrlPermissions().hasRules())
-                ctrlPerm.setVisible(false);
-            else
-                ctrlPerm.setOnPreferenceClickListener(preference -> {
-                    Intent intent = new Intent(requireContext(), EditCtrlPermissions.class);
-                    startActivity(intent);
-                    return true;
-                });
+            ctrlPerm.setOnPreferenceClickListener(preference -> {
+                Intent intent = new Intent(requireContext(), EditCtrlPermissions.class);
+                startActivity(intent);
+                return true;
+            });
         }
 
         private void rootCaptureHideShow(boolean enabled) {

--- a/app/src/main/java/com/emanuelef/remote_capture/model/Prefs.java
+++ b/app/src/main/java/com/emanuelef/remote_capture/model/Prefs.java
@@ -110,6 +110,7 @@ public class Prefs {
     public static final String PREF_PCAPNG_ENABLED = "pcapng_format";
     public static final String PREF_RESTART_ON_DISCONNECT = "restart_on_disconnect";
     public static final String PREF_IGNORED_MITM_VERSION = "ignored_mitm_version";
+    public static final String PREF_API_KEY = "api_key";
 
     public enum DumpMode {
         NONE,
@@ -238,6 +239,7 @@ public class Prefs {
     public static String getDnsServerV4(SharedPreferences p)    { return(p.getString(PREF_DNS_SERVER_V4, "1.1.1.1")); }
     public static String getDnsServerV6(SharedPreferences p)    { return(p.getString(PREF_DNS_SERVER_V6, "2606:4700:4700::1111")); }
     public static boolean isIgnoredMitmVersion(SharedPreferences p, String v) { return p.getString(PREF_IGNORED_MITM_VERSION, "").equals(v); }
+    public static String getApiKey(SharedPreferences p)         { return(p.getString(PREF_API_KEY, "")); }
 
     // Gets a StringSet from the prefs
     // The preference should either be a StringSet or a String

--- a/app/src/main/res/menu/ctrl_permissions_menu.xml
+++ b/app/src/main/res/menu/ctrl_permissions_menu.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/user_guide"
+        android:title="@string/user_guide"
+        android:orderInCategory="10"
+        android:icon="@drawable/ic_book"
+        app:showAsAction="ifRoom" />
+
+    <item
+        android:id="@+id/show_api_key"
+        android:title="@string/show_api_key"
+        android:orderInCategory="20"
+        app:showAsAction="never" />
+
+    <item
+        android:id="@+id/generate_api_key"
+        android:title="@string/generate_api_key"
+        android:orderInCategory="20"
+        app:showAsAction="never" />
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -217,6 +217,11 @@
     <string name="control_permissions">Control permissions</string>
     <string name="control_permissions_summary">Check which apps are allowed to control the PCAPdroid capture</string>
     <string name="control_permissions_item">%1$s: %2$s</string>
+    <string name="no_permissions_set_info">No permissions set. Invoke PCAPdroid via StartActivityForResult to show the permissions prompt</string>
+    <string name="generate_api_key">Generate API key</string>
+    <string name="show_api_key">Show API key</string>
+    <string name="api_key">API key</string>
+    <string name="api_key_discard_confirm">Do you really want to discard the current API key and generate a new one?</string>
     <string name="country">Country</string>
     <string name="asn">ASN</string>
     <string name="country_val">Country: %1$s</string>


### PR DESCRIPTION
It's now possible to generate an API key to be set in the Intent, allowing to control the PCAPdroid capture without prompt

Closes #516