### PR TITLE
fix: fix the display of unicode characters in wireshark

### DIFF
--- a/tools/pcapdroid.lua
+++ b/tools/pcapdroid.lua
@@ -70,7 +70,7 @@ local function dissect_pcap_trailer(buffer, pinfo, tree)
 
   subtree:add(fields.magic, trailer(0, 4))
   subtree:add(fields.uid, trailer(4, 4))
-  subtree:add(fields.appname, trailer(8, 20))
+  subtree:add(fields.appname, appname):set_text("App name: " .. appname)
   return true
 end
 

--- a/tools/pcapdroid.lua
+++ b/tools/pcapdroid.lua
@@ -70,7 +70,7 @@ local function dissect_pcap_trailer(buffer, pinfo, tree)
 
   subtree:add(fields.magic, trailer(0, 4))
   subtree:add(fields.uid, trailer(4, 4))
-  subtree:add(fields.appname, appname):set_text("App name: " .. appname)
+  subtree:add(fields.appname, appname)
   return true
 end
 


### PR DESCRIPTION
Closes #844

Since I don’t have a license for the premium version, I haven’t tested how the appname is displayed in the PCAPNG format, but I suspect there might be a similar issue.