### PR TITLE
Add more known DNS addresses and DOT/DOH domains

### DIFF
--- a/app/src/main/jni/core/capture_vpn.c
+++ b/app/src/main/jni/core/capture_vpn.c
@@ -413,33 +413,139 @@ void vpn_process_ndpi(pcapdroid_t *pd, const zdtun_5tuple_t *tuple, pd_conn_t *d
 /* ******************************************************* */
 
 static void load_dns_servers(pcapdroid_t *pd) {
-    // IP addresses (both legacy and private DNS). These are used to count DNS queries and
+    // IP addresses (both legacy and private DNS) and domains (only private DNS). These are used to count DNS queries and
     // redirect DNS queries to the public DNS server (see check_dns_req_allowed)
+    // https://help.firewalla.com/hc/en-us/articles/360060661873-Dealing-DNS-over-HTTPS-and-DNS-over-TLS-on-your-network
+    // https://adguard-dns.io/kb/general/dns-providers/
+    // Google
     blacklist_add_ipstr(pd->vpn.known_dns_servers, "8.8.8.8");
     blacklist_add_ipstr(pd->vpn.known_dns_servers, "8.8.4.4");
-    blacklist_add_ipstr(pd->vpn.known_dns_servers, "1.1.1.1");
-    blacklist_add_ipstr(pd->vpn.known_dns_servers, "1.0.0.1");
     blacklist_add_ipstr(pd->vpn.known_dns_servers, "2001:4860:4860::8888");
     blacklist_add_ipstr(pd->vpn.known_dns_servers, "2001:4860:4860::8844");
-    blacklist_add_ipstr(pd->vpn.known_dns_servers, "2606:4700:4700::64");
-    blacklist_add_ipstr(pd->vpn.known_dns_servers, "2606:4700:4700::6400");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "2001:4860:4860::6464"); // DNS64
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "2001:4860:4860::64");   // DNS64
+    blacklist_add_domain(pd->vpn.known_dns_servers, "dns.google");
+    // Cloudflare
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "1.1.1.1");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "1.0.0.1");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "1.1.1.2");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "1.0.0.2");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "1.1.1.3");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "1.0.0.3");
     blacklist_add_ipstr(pd->vpn.known_dns_servers, "2606:4700:4700::1111");
     blacklist_add_ipstr(pd->vpn.known_dns_servers, "2606:4700:4700::1001");
-
-    // Domains (only private DNS)
-    // https://help.firewalla.com/hc/en-us/articles/360060661873-Dealing-DNS-over-HTTPS-and-DNS-over-TLS-on-your-network
-    blacklist_add_domain(pd->vpn.known_dns_servers, "dns.google");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "2606:4700:4700::1112");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "2606:4700:4700::1002");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "2606:4700:4700::1113");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "2606:4700:4700::1003");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "2606:4700:4700::64");   // DNS64
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "2606:4700:4700::6400"); // DNS64
+    blacklist_add_domain(pd->vpn.known_dns_servers, "one.one.one.one");
+    blacklist_add_domain(pd->vpn.known_dns_servers, "dns.cloudflare.com");
     blacklist_add_domain(pd->vpn.known_dns_servers, "chrome.cloudflare-dns.com");
     blacklist_add_domain(pd->vpn.known_dns_servers, "mozilla.cloudflare-dns.com");
+    blacklist_add_domain(pd->vpn.known_dns_servers, "security.cloudflare-dns.com");
+    blacklist_add_domain(pd->vpn.known_dns_servers, "family.cloudflare-dns.com");
+    // Quad9
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "9.9.9.9");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "149.112.112.112");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "9.9.9.10");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "149.112.112.10");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "9.9.9.11");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "149.112.112.11");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "2620:fe::fe");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "2620:fe::9");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "2620:fe::10");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "2620:fe::fe:10");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "2620:fe::11");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "2620:fe::fe:11");
+    blacklist_add_domain(pd->vpn.known_dns_servers, "dns.quad9.net");
+    blacklist_add_domain(pd->vpn.known_dns_servers, "dns10.quad9.net");
+    blacklist_add_domain(pd->vpn.known_dns_servers, "dns11.quad9.net");
+    // CleanBrowsing
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "185.228.168.168");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "185.228.169.168");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "185.228.168.10");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "185.228.169.11");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "185.228.168.9");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "185.228.169.9");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "2a0d:2a00:1::");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "2a0d:2a00:2::");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "2a0d:2a00:1::1");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "2a0d:2a00:2::1");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "2a0d:2a00:1::2");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "2a0d:2a00:2::2");
     blacklist_add_domain(pd->vpn.known_dns_servers, "doh.cleanbrowsing.org");
+    blacklist_add_domain(pd->vpn.known_dns_servers, "family-filter-dns.cleanbrowsing.org");
+    blacklist_add_domain(pd->vpn.known_dns_servers, "adult-filter-dns.cleanbrowsing.org");
+    blacklist_add_domain(pd->vpn.known_dns_servers, "security-filter-dns.cleanbrowsing.org");
+    // NextDNS
+    blacklist_add_domain(pd->vpn.known_dns_servers, "dns.nextdns.io");
+    blacklist_add_domain(pd->vpn.known_dns_servers, "anycast.dns.nextdns.io");
     blacklist_add_domain(pd->vpn.known_dns_servers, "chromium.dns.nextdns.io");
     blacklist_add_domain(pd->vpn.known_dns_servers, "firefox.dns.nextdns.io");
-    blacklist_add_domain(pd->vpn.known_dns_servers, "dns.quad9.net");
+    // OpenDNS
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "208.67.222.222");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "208.67.220.220");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "208.67.222.123");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "208.67.220.123");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "208.67.222.2");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "208.67.220.2");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "2620:119:35::35");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "2620:119:53::53");
     blacklist_add_domain(pd->vpn.known_dns_servers, "doh.opendns.com");
+    blacklist_add_domain(pd->vpn.known_dns_servers, "dns.opendns.com");
+    blacklist_add_domain(pd->vpn.known_dns_servers, "doh.familyshield.opendns.com");
+    blacklist_add_domain(pd->vpn.known_dns_servers, "familyshield.opendns.com");
+    blacklist_add_domain(pd->vpn.known_dns_servers, "doh.sandbox.opendns.com");
+    blacklist_add_domain(pd->vpn.known_dns_servers, "sandbox.opendns.com");
+    // Adguard
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "94.140.14.14");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "94.140.15.15");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "94.140.14.15");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "94.140.15.16");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "94.140.14.140");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "94.140.14.141");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "2a10:50c0::ad1:ff");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "2a10:50c0::ad2:ff");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "2a10:50c0::bad1:ff");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "2a10:50c0::bad2:ff");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "2a10:50c0::1:ff");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "2a10:50c0::2:ff");
     blacklist_add_domain(pd->vpn.known_dns_servers, "dns.adguard.com");
+    blacklist_add_domain(pd->vpn.known_dns_servers, "dns.adguard-dns.com");
+    blacklist_add_domain(pd->vpn.known_dns_servers, "family.adguard-dns.com");
+    blacklist_add_domain(pd->vpn.known_dns_servers, "unfiltered.adguard-dns.com");
+    // LibreDNS
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "88.198.92.222");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "116.202.176.26");
     blacklist_add_domain(pd->vpn.known_dns_servers, "dot.libredns.gr");
+    blacklist_add_domain(pd->vpn.known_dns_servers, "doh.libredns.gr");
+    // DNSLify
     blacklist_add_domain(pd->vpn.known_dns_servers, "dns.dnslify.com");
+    // Quadrant Security
     blacklist_add_domain(pd->vpn.known_dns_servers, "dns-tls.qis.io");
+    blacklist_add_domain(pd->vpn.known_dns_servers, "doh.qis.io");
+    // Mullvad
+    blacklist_add_domain(pd->vpn.known_dns_servers, "dns.mullvad.net");
+    blacklist_add_domain(pd->vpn.known_dns_servers, "adblock.dns.mullvad.net");
+    blacklist_add_domain(pd->vpn.known_dns_servers, "base.dns.mullvad.net");
+    blacklist_add_domain(pd->vpn.known_dns_servers, "extended.dns.mullvad.net");
+    blacklist_add_domain(pd->vpn.known_dns_servers, "family.dns.mullvad.net");
+    blacklist_add_domain(pd->vpn.known_dns_servers, "all.dns.mullvad.net");
+    // ControlD
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "76.76.2.0");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "76.76.10.0");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "76.76.2.1");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "76.76.2.2");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "76.76.2.3");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "2606:1a40::");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "2606:1a40:1::");
+    blacklist_add_domain(pd->vpn.known_dns_servers, "freedns.controld.com");
+    blacklist_add_domain(pd->vpn.known_dns_servers, "p0.freedns.controld.com");
+    blacklist_add_domain(pd->vpn.known_dns_servers, "p1.freedns.controld.com");
+    blacklist_add_domain(pd->vpn.known_dns_servers, "p2.freedns.controld.com");
+    blacklist_add_domain(pd->vpn.known_dns_servers, "p3.freedns.controld.com");
 }
 
 /* ******************************************************* */

--- a/app/src/main/jni/core/capture_vpn.c
+++ b/app/src/main/jni/core/capture_vpn.c
@@ -519,6 +519,7 @@ static void load_dns_servers(pcapdroid_t *pd) {
     // LibreDNS
     blacklist_add_ipstr(pd->vpn.known_dns_servers, "88.198.92.222");
     blacklist_add_ipstr(pd->vpn.known_dns_servers, "116.202.176.26");
+    blacklist_add_ipstr(pd->vpn.known_dns_servers, "2a01:4f8:1c0c:8274::1");
     blacklist_add_domain(pd->vpn.known_dns_servers, "dot.libredns.gr");
     blacklist_add_domain(pd->vpn.known_dns_servers, "doh.libredns.gr");
     // DNSLify


### PR DESCRIPTION
Improve DNS capturing and blocking by adding more addresses and domains for already known DNS services and include a couple more popular providers.

Some IPs are from my own research and some are from this all-inclusive list:
https://adguard-dns.io/kb/general/dns-providers/
I have added it as a comment for future convenience, can be removed if this is a concern for advertising/privacy.

I have decided against adding any providers less popular then these because there is a ton of them and there are a few bad apples which not trustworthy at all, and I do not think they should be mentioned anywhere in the project. A comprehensive research is needed for each and I do not think it is practical.
If you have any other specific service in mind - I will gladly add it here.
